### PR TITLE
Upload demo artifacts only on schedule, push

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -9,6 +9,8 @@ on:
   schedule:
     - cron: '00 21 * * *'
   pull_request:
+  push:
+    branches: [ main ]
 
 jobs:
   build:
@@ -99,13 +101,17 @@ jobs:
         path: ${{ github.workspace }}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
         retention-days: 5
 
+    # Upload Cilium demo artifacts only for 'schedule' and 'push'
     - name: Upload Compiled Cilium XDP Files
+      if: github.event_name == 'schedule' || github.event_name == 'push'
       uses: actions/upload-artifact@v2.2.4
       with:
         name: x64-${{ matrix.configurations }}-cilium-xdp
         path: ${{ github.workspace }}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}/cilium/object/*
         retention-days: 5
 
+    # Run tests only for 'schedule' and 'pull_request'
     - name: Run Cilium XDP Tests
+      if: github.event_name == 'schedule' || github.event_name == 'pull_request'
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: ./cilium_test.exe -s


### PR DESCRIPTION
**Issue:**

Currently the demo artifacts are uploaded on `schedule` and `pull_request`. This can cause an incorrect PR to upload incorrect artifacts. 

**Fix:**
Changed CICD to also run on `push`. Also, artifacts will be uploaded only on `schedule` and `push` now.