### PR TITLE
Enable dependabot in ebpf-for-windows-demo repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,8 +27,3 @@ updates:
       interval: "weekly"
       day: "saturday"
 
-  - package-ecosystem: "docker"
-    directory: "/images"
-    schedule:
-      interval: "weekly"
-      day: "saturday"


### PR DESCRIPTION
This repo should use dependabot to keep up to date.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>