### PR TITLE
Missing stdbool in bpf_xdp.vcxproj

### DIFF
--- a/cilium/load_balancer/bpf/bpf_xdp/bpf_xdp.vcxproj
+++ b/cilium/load_balancer/bpf/bpf_xdp/bpf_xdp.vcxproj
@@ -138,6 +138,7 @@
 xcopy $(EbpfIncludePath)\* $(SolutionDir)$(Platform)\$(Configuration)\include\* /E/Y
 xcopy $(SolutionDir)cilium\load_balancer\windows_types.h $(SolutionDir)$(Platform)\$(Configuration)\include\* /E/Y
 xcopy $(SolutionDir)cilium\load_balancer\stdint.h $(SolutionDir)$(Platform)\$(Configuration)\include\* /E/Y
+xcopy $(SolutionDir)cilium\load_balancer\stdbool.h $(SolutionDir)$(Platform)\$(Configuration)\include\* /E/Y
 xcopy $(SolutionDir)cilium\load_balancer\guiddef.h $(SolutionDir)$(Platform)\$(Configuration)\include\* /E/Y
 xcopy $(SolutionDir)cilium\load_balancer\bpf\node_config_static.h $(SolutionDir)$(Platform)\$(Configuration)\bpf\ /Y
 xcopy $(SolutionDir)cilium\load_balancer\bpf\netdev_config_snat.h $(SolutionDir)$(Platform)\$(Configuration)\bpf\ /Y
@@ -182,6 +183,7 @@ xcopy $(SolutionDir)cilium\load_balancer\bpf\netdev_config_dsr.h $(SolutionDir)$
 xcopy $(EbpfIncludePath)\* $(SolutionDir)$(Platform)\$(Configuration)\include\* /E/Y
 xcopy $(SolutionDir)cilium\load_balancer\windows_types.h $(SolutionDir)$(Platform)\$(Configuration)\include\* /E/Y
 xcopy $(SolutionDir)cilium\load_balancer\stdint.h $(SolutionDir)$(Platform)\$(Configuration)\include\* /E/Y
+xcopy $(SolutionDir)cilium\load_balancer\stdbool.h $(SolutionDir)$(Platform)\$(Configuration)\include\* /E/Y
 xcopy $(SolutionDir)cilium\load_balancer\guiddef.h $(SolutionDir)$(Platform)\$(Configuration)\include\* /E/Y
 xcopy $(SolutionDir)cilium\load_balancer\bpf\node_config_static.h $(SolutionDir)$(Platform)\$(Configuration)\bpf\ /Y
 xcopy $(SolutionDir)cilium\load_balancer\bpf\netdev_config_snat.h $(SolutionDir)$(Platform)\$(Configuration)\bpf\ /Y


### PR DESCRIPTION
Fixes #18 

Problem: stdbool.h was not present in the include.

Solution: 
In bpf_xdp.vcxproj, copied the stdbool.h from cilium\load_balancer\stdbool.h to the platform's include directory.

Test:
C:\ebpf-2023\ebpf-for-windows-demo\x64\Debug\include>dir stdbool.h
 Volume in drive C has no label.
 Volume Serial Number is 2455-1CFB

 Directory of C:\ebpf-2023\ebpf-for-windows-demo\x64\Debug\include

06/12/2023  10:31 PM                84 stdbool.h
               1 File(s)             84 bytes
               0 Dir(s)  111,027,269,632 bytes free

C:\ebpf-2023\ebpf-for-windows-demo\x64\Debug\include>

C:\ebpf-2023\ebpf-for-windows-demo\x64\Debug>.\cilium_based_agent.exe --bpf-lb-mode=snat --device=ethernet
Initializing daemon with mode = snat
Using interface:
  name         = ethernet
  mtu          = 1500
  ifindex      = 9
  IPv4 address = 169.254.101.203

Cleaning up previous configuration ...
Compiling XDP eBPF program for SNAT ...
Compile command: clang -g -O2 -target bpf -mcpu=v1 -std=gnu89 -nostdinc -Wextra -Werror -Wshadow -Wno-address-of-packed-member -Wno-unknown-warning-option -Wno-gnu-variable-sized-type-not-at-end -Wdeclaration-after-statement -DSECLABEL=2 -Dcapture_enabled=0 -DDISABLE_LOOPBACK_LB -DCALLS_MAP=cilium_calls_xdp -I.\include -I. -I..\ -I..\include -DMODE_SNAT -DEBPF_FOR_WINDOWS -D__NR_CPUS__=48 -DNODE_MAC={.addr={0xb4,0x96,0x91,0x6c,0xa6,0xf7}} -DNATIVE_DEV_IFINDEX=9 -c bpf_xdp.c -o ..\bpf_xdp_snat.o
Verifying the program ...
Loading and attaching the program to XDP hook ...
bpf_object__load failed with error 0
Initialization complete.

>$ exit