### PR TITLE
Update cilium submodule

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -113,7 +113,9 @@ jobs:
         retention-days: 5
 
     # Run tests only for 'schedule' and 'pull_request'
-    - name: Run Cilium XDP Tests
-      if: github.event_name == 'schedule' || github.event_name == 'pull_request'
-      working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
-      run: ./cilium_test.exe -s
+    # Re-enable this tests once next version of eBPF-for-Windows is released.
+    # Tracked by GitHub issue #91
+    # - name: Run Cilium XDP Tests
+    #   if: github.event_name == 'schedule' || github.event_name == 'pull_request'
+    #   working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
+    #   run: ./cilium_test.exe -s


### PR DESCRIPTION
This PR updates the Cilium submodule. Cilium fork was updated to start using LIBBPF_* pin options.

This PR is also disabling Cilium tests which verifies the Cilium XDP ebpf programs. These will be disabled till the time next release of eBPF-for-windows comes out with LIBBPF_PIN_TYPE* changes. Few notes::
1. There is a cyclic dependency between this repo and ebpf-for-windows repo. Due to that making LIBBPF PIN type changes are causing failures in both the repos.
2. ebpf-for-windows repo also has cilium xdp verification tests, so effectively will not miss on any tests.